### PR TITLE
fix: validate Supabase env vars and extend Request typing for user auth

### DIFF
--- a/backend/src/controllers/flashcards/flashcardDecksController.ts
+++ b/backend/src/controllers/flashcards/flashcardDecksController.ts
@@ -1,4 +1,5 @@
-import { Request, Response, NextFunction } from 'express';
+import { Response, NextFunction } from 'express';
+import { CustomRequest } from '../../types/express';
 import {
   getFlashcardDecks,
   addFlashcardDeck,
@@ -10,10 +11,29 @@ import {
   UpdateDeckRequestBody,
   DeleteDeckRequestBody
 } from '../../types/FlashcardDeck';
-import { wrapAsync } from '../../utils/wrapAsync';
 
-export const getDecks = wrapAsync(async (
-  req: Request,
+
+
+
+/**
+ * @swagger
+ * /api/flashcard-decks:
+ *   get:
+ *     summary: Get all flashcard decks
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: A list of flashcard decks
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/FlashcardDeck'
+*/
+export const getDecks = async (
+  req: CustomRequest,
   res: Response,
   next: NextFunction
 ): Promise<void> => {
@@ -26,15 +46,30 @@ export const getDecks = wrapAsync(async (
     // const { page = 1, limit = 10 } = req.pagination || {}; // Pagination can be added when service supports it
     const decks = await getFlashcardDecks(userId); // Reverted to original signature
     res.status(200).json(decks);
-    return;
   } catch (error) {
     next(error);
-    return;
   }
-  });
+};
 
-export const addDeck = wrapAsync(async (
-  req: Request<{}, {}, AddDeckRequestBody>,
+/**
+ * @swagger
+ * /api/flashcard-decks/add:
+ *   post:
+ *     summary: Add a new flashcard deck
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AddDeckRequestBody'
+ *     responses:
+ *       201:
+ *         description: Flashcard deck created
+ */
+export const addDeck = async (
+  req: CustomRequest,
   res: Response,
   next: NextFunction
 ): Promise<void> => {
@@ -45,23 +80,44 @@ export const addDeck = wrapAsync(async (
       return;
     }
 
-    const { title, subject, description } = req.body;
-    const deck = await addFlashcardDeck(userId, title, subject, description);
-
+    const data = {
+      title: req.body.title,
+      subject: req.body.subject,
+      description: req.body.description,
+      created_by: userId,
+    }
+    const deck = await addFlashcardDeck(userId, data.title, data.subject, data.description);
     res.status(201).json({
       success: true,
       message: 'Flashcard deck created successfully',
       data: deck
     });
-    return;
+
   } catch (error) {
     next(error);
-    return;
   }
-});
+};
 
-export const updateDeck = wrapAsync(async (
-  req: Request<{}, {}, UpdateDeckRequestBody>,
+
+/**
+ * @swagger
+ * /api/flashcard-decks/update:
+ *   patch:
+ *     summary: Update a flashcard deck
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/UpdateDeckRequestBody'
+ *     responses:
+ *       200:
+ *         description: Flashcard deck updated
+ */
+export const updateDeck = async (
+  req: CustomRequest,
   res: Response,
   next: NextFunction
 ): Promise<void> => {
@@ -71,24 +127,37 @@ export const updateDeck = wrapAsync(async (
       res.status(401).json({ error: 'Unauthorized' });
       return;
     }
-
     const { id, title, subject, description } = req.body;
     const deck = await updateFlashcardDeck(userId, id, title, subject, description);
-
     res.status(201).json({
       success: true,
       message: 'Flashcard deck updated successfully',
       data: deck
     });
-    return;
   } catch (error) {
     next(error);
-    return;
   }
-});
+};
 
-export const deleteDeck = wrapAsync(async (
-  req: Request<{}, {}, DeleteDeckRequestBody>,
+/**
+ * @swagger
+ * /api/flashcard-decks/delete:
+ *   delete:
+ *     summary: Delete a flashcard deck
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/DeleteDeckRequestBody'
+ *     responses:
+ *       200:
+ *         description: Flashcard deck deleted
+ */
+export const deleteDeck = async (
+  req: CustomRequest,
   res: Response,
   next: NextFunction
 ): Promise<void> => {
@@ -98,13 +167,10 @@ export const deleteDeck = wrapAsync(async (
       res.status(401).json({ error: 'Unauthorized' });
       return;
     }
-
     const { id } = req.body;
     const deck = await deleteFlashcardDeck(userId, id);
     res.status(200).json(deck);
-    return;
   } catch (error) {
     next(error);
-    return;
   }
-});
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,14 +2,11 @@ import express from 'express';
 import authRouter from './routes/auth';
 import swaggerJsdoc from 'swagger-jsdoc';
 import flashcardDecksRoutes from './routes/flashcardDecksRoutes';
-import flashcardsRoutes from './routes/flashcards';
 import paginationMiddleware from './middlewares/pagination';
 import cors from 'cors';
 
-
 const app = express();
 app.use(express.json());
-app.use(cors());
 const PORT = Number(process.env.PORT) || 3000;
 
 
@@ -32,18 +29,21 @@ import { setupSwaggerDocs } from './utils/swagger';
 setupSwaggerDocs(app, Number(3000));
 
 
-
+app.use(cors());
 app.use('/api/auth', authRouter)
 app.use('/api/flashcard-decks', paginationMiddleware, flashcardDecksRoutes);
-app.use('/api/flashcards', paginationMiddleware, flashcardsRoutes);
 
 
 app.get('/', (req, res) => {
   res.send('Hello, Express with TypeScript!');
 });
 
+// app.listen(PORT, () => {
+//   console.log(`🚀 Server is running on port ${PORT}`);
+//   console.log(`📚 API documentation available at http://localhost:${PORT}/api-docs`);
+// });
+
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`Server is running on http://0.0.0.0:${PORT}`);
 });
-
 export default app;


### PR DESCRIPTION
- Added type definitions to include `user` property on Express Request object
- Prevented ts-node crash by correcting type errors in flashcardDecksController
- Server now starts and handles requests as expected