### PR TITLE
External Deck Explorer

### DIFF
--- a/backend/src/services/flashcardDecksService.ts
+++ b/backend/src/services/flashcardDecksService.ts
@@ -4,6 +4,7 @@ export const getFlashcardDecks = async (userId: string) => {
   const { data, error } = await supabase
     .from('flashcard_decks')
     .select('*')
+    .order('created_at', { ascending: false })
     .eq('created_by', userId);
 
   if (error) throw new Error(error.message);

--- a/frontend/app/(tabs)/(explore)/_layout.tsx
+++ b/frontend/app/(tabs)/(explore)/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router';
+
+export default function HomeLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="index" />
+      <Stack.Screen name="subjectCards" />
+    </Stack>
+  );
+}

--- a/frontend/app/(tabs)/(explore)/explore.tsx
+++ b/frontend/app/(tabs)/(explore)/explore.tsx
@@ -1,111 +1,185 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import React from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  ScrollView,
+  Pressable,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+import { Formik } from 'formik';
+import * as Yup from 'yup';
+import { useRouter } from 'expo-router';
 
-import { Collapsible } from '@/components/Collapsible';
-import { ExternalLink } from '@/components/ExternalLink';
-import ParallaxScrollView from '@/components/ParallaxScrollView';
-import { ThemedText } from '@/components/ThemedText';
-import { ThemedView } from '@/components/ThemedView';
-import { IconSymbol } from '@/components/ui/IconSymbol';
+const categories = [
+  'Any Category',
+  'General Knowledge',
+  'Entertainment: Books',
+  'Entertainment: Film',
+  'Entertainment: Music',
+  'Entertainment: Musicals & Theatres',
+  'Entertainment: Television',
+  'Entertainment: Video Games',
+  'Entertainment: Board Games',
+  'Science & Nature',
+  'Science: Computers',
+  'Science: Mathematics',
+  'Mythology',
+  'Sports',
+  'Geography',
+  'History',
+  'Politics',
+  'Art',
+  'Celebrities',
+  'Animals',
+  'Vehicles',
+  'Entertainment: Comics',
+  'Science: Gadgets',
+  'Entertainment: Japanese Anime & Manga',
+  'Entertainment: Cartoon & Animations',
+];
 
-export default function ExploreDecks() {
+const difficulties = ['Any Difficulty', 'Easy', 'Medium', 'Hard'];
+
+const ExploreDeckScreen = () => {
+  const router = useRouter();
+
+  const validationSchema = Yup.object().shape({
+    amount: Yup.number().min(1).max(50).required('Number of questions is required'),
+    category: Yup.string().required('Please choose category'),
+    difficulty: Yup.string().required('Please choose difficulty'),
+  });
+
+  const initialValues = {
+    amount: '10',
+    category: 'Any Category',
+    difficulty: 'Any Difficulty',
+  };
+
+  async function handleSubmit(
+    values: typeof initialValues,
+    { resetForm }: { resetForm: () => void }
+  ) {
+    console.log('Explore with values:', values);
+    // TODO: Call Zustand action here
+    router.push({ pathname: './../(home)/subjectCards', params: { explore: 'yes' } });
+    resetForm();
+  }
+
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
-      headerImage={
-        <IconSymbol
-          size={310}
-          color="#808080"
-          name="chevron.left.forwardslash.chevron.right"
-          style={styles.headerImage}
-        />
-      }
+    <Formik
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      onSubmit={handleSubmit}
     >
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Explore</ThemedText>
-      </ThemedView>
-      <ThemedText>This app includes example code to help you get started.</ThemedText>
-      <Collapsible title="File-based routing">
-        <ThemedText>
-          This app has two screens:{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/explore.tsx</ThemedText>
-        </ThemedText>
-        <ThemedText>
-          The layout file in <ThemedText type="defaultSemiBold">app/(tabs)/_layout.tsx</ThemedText>{' '}
-          sets up the tab navigator.
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/router/introduction">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Android, iOS, and web support">
-        <ThemedText>
-          You can open this project on Android, iOS, and the web. To open the web version, press{' '}
-          <ThemedText type="defaultSemiBold">w</ThemedText> in the terminal running this project.
-        </ThemedText>
-      </Collapsible>
-      <Collapsible title="Images">
-        <ThemedText>
-          For static images, you can use the <ThemedText type="defaultSemiBold">@2x</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">@3x</ThemedText> suffixes to provide files for
-          different screen densities
-        </ThemedText>
-        <Image source={require('@/assets/images/react-logo.png')} style={{ alignSelf: 'center' }} />
-        <ExternalLink href="https://reactnative.dev/docs/images">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Custom fonts">
-        <ThemedText>
-          Open <ThemedText type="defaultSemiBold">app/_layout.tsx</ThemedText> to see how to load{' '}
-          <ThemedText style={{ fontFamily: 'SpaceMono' }}>
-            custom fonts such as this one.
-          </ThemedText>
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/versions/latest/sdk/font">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Light and dark mode components">
-        <ThemedText>
-          This template has light and dark mode support. The{' '}
-          <ThemedText type="defaultSemiBold">useColorScheme()</ThemedText> hook lets you inspect
-          what the user&apos;s current color scheme is, and so you can adjust UI colors accordingly.
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Animations">
-        <ThemedText>
-          This template includes an example of an animated component. The{' '}
-          <ThemedText type="defaultSemiBold">components/HelloWave.tsx</ThemedText> component uses
-          the powerful <ThemedText type="defaultSemiBold">react-native-reanimated</ThemedText>{' '}
-          library to create a waving hand animation.
-        </ThemedText>
-        {Platform.select({
-          ios: (
-            <ThemedText>
-              The <ThemedText type="defaultSemiBold">components/ParallaxScrollView.tsx</ThemedText>{' '}
-              component provides a parallax effect for the header image.
-            </ThemedText>
-          ),
-        })}
-      </Collapsible>
-    </ParallaxScrollView>
+      {({ handleChange, handleBlur, handleSubmit, values, errors, touched }) => (
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={{ flex: 1, backgroundColor: '#f4f4f5' }}
+        >
+          <ScrollView
+            contentContainerStyle={{ flexGrow: 1, padding: 20 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+              <Text style={styles.title}>Explore External Decks</Text>
+
+              {/* Number of Questions */}
+              <Text style={styles.label}>Number of Questions</Text>
+              <TextInput
+                keyboardType="numeric"
+                value={values.amount}
+                onChangeText={handleChange('amount')}
+                onBlur={handleBlur('amount')}
+                style={styles.input}
+              />
+              {touched.amount && errors.amount && <Text style={styles.error}>{errors.amount}</Text>}
+
+              {/* Category */}
+              <Text style={styles.label}>Select Category</Text>
+              <TextInput
+                value={values.category}
+                onChangeText={handleChange('category')}
+                onBlur={handleBlur('category')}
+                placeholder="Category"
+                style={styles.input}
+              />
+              {touched.category && errors.category && (
+                <Text style={styles.error}>{errors.category}</Text>
+              )}
+
+              {/* Difficulty */}
+              <Text style={styles.label}>Select Difficulty</Text>
+              <TextInput
+                value={values.difficulty}
+                onChangeText={handleChange('difficulty')}
+                onBlur={handleBlur('difficulty')}
+                placeholder="Difficulty"
+                style={styles.input}
+              />
+              {touched.difficulty && errors.difficulty && (
+                <Text style={styles.error}>{errors.difficulty}</Text>
+              )}
+
+              {/* Submit */}
+              <Pressable onPress={() => handleSubmit()} style={styles.button}>
+                <Text style={styles.buttonText}>Explore</Text>
+              </Pressable>
+
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      )}
+    </Formik>
   );
-}
+};
+
+export default ExploreDeckScreen;
 
 const styles = StyleSheet.create({
-  headerImage: {
-    color: '#808080',
-    bottom: -90,
-    left: -35,
-    position: 'absolute',
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    textAlign: 'center',
   },
-  titleContainer: {
-    flexDirection: 'row',
-    gap: 8,
+  label: {
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 6,
+    marginTop: 12,
+  },
+  input: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  error: {
+    color: 'red',
+    fontSize: 12,
+    marginTop: 4,
+  },
+  button: {
+    backgroundColor: '#4f46e5',
+    marginTop: 24,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+    shadowColor: '#4f46e5',
+    shadowOpacity: 0.5,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    opacity: 1,
+  },
+  buttonText: {
+    color: 'white',
+    fontWeight: '600',
+    fontSize: 18,
   },
 });

--- a/frontend/app/(tabs)/(explore)/index.tsx
+++ b/frontend/app/(tabs)/(explore)/index.tsx
@@ -14,6 +14,7 @@ import * as Yup from 'yup';
 import { useRouter } from 'expo-router';
 import { Menu, Button } from 'react-native-paper';
 import { useFocusEffect } from '@react-navigation/native';
+import { useExploreDeckStore } from '@/store/explore-deck-store';
 
 const categories = [
   'Any Category',
@@ -49,6 +50,7 @@ const ExploreDeckScreen = () => {
   const router = useRouter();
   const [categoryMenuVisible, setCategoryMenuVisible] = useState(false);
   const [difficultyMenuVisible, setDifficultyMenuVisible] = useState(false);
+  const { fetchExploreDeck } = useExploreDeckStore();
 
   const validationSchema = Yup.object().shape({
     amount: Yup.number().min(1).max(50).required('Number of questions is required'),
@@ -79,6 +81,7 @@ const ExploreDeckScreen = () => {
   ) {
     console.log('Explore with values:', values);
     // TODO: Call Zustand action here
+    await fetchExploreDeck(values.amount, values.category, values.difficulty);
     router.push({
       pathname: './subjectCards',
       params: { category: values.category, difficulty: values.difficulty, amount: values.amount },

--- a/frontend/app/(tabs)/(explore)/index.tsx
+++ b/frontend/app/(tabs)/(explore)/index.tsx
@@ -80,7 +80,6 @@ const ExploreDeckScreen = () => {
     { resetForm }: { resetForm: () => void }
   ) {
     console.log('Explore with values:', values);
-    // TODO: Call Zustand action here
     await fetchExploreDeck(values.amount, values.category, values.difficulty);
     router.push({
       pathname: './subjectCards',

--- a/frontend/app/(tabs)/(explore)/index.tsx
+++ b/frontend/app/(tabs)/(explore)/index.tsx
@@ -79,7 +79,6 @@ const ExploreDeckScreen = () => {
     values: typeof initialValues,
     { resetForm }: { resetForm: () => void }
   ) {
-    console.log('Explore with values:', values);
     await fetchExploreDeck(values.amount, values.category, values.difficulty);
     router.push({
       pathname: './subjectCards',

--- a/frontend/app/(tabs)/(explore)/index.tsx
+++ b/frontend/app/(tabs)/(explore)/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -14,7 +14,6 @@ import * as Yup from 'yup';
 import { useRouter } from 'expo-router';
 import { Menu, Button } from 'react-native-paper';
 import { useFocusEffect } from '@react-navigation/native';
-import { useCallback } from 'react';
 
 const categories = [
   'Any Category',
@@ -199,7 +198,6 @@ const ExploreDeckScreen = () => {
               <Pressable onPress={() => handleSubmit()} style={styles.button}>
                 <Text style={styles.buttonText}>Explore</Text>
               </Pressable>
-
             </View>
           </ScrollView>
         </KeyboardAvoidingView>

--- a/frontend/app/(tabs)/(explore)/subjectCards.tsx
+++ b/frontend/app/(tabs)/(explore)/subjectCards.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+} from 'react-native';
+
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import mockData from '@/data/flashcards.json';
+
+export default function SubjectCardsScreen() {
+  const router = useRouter();
+  const { category, amount } = useLocalSearchParams();
+
+  const isLoading = false;
+  const error = false;
+
+  function handleSaveDeck() {
+    console.log('runs function from zustand to save to supabase');
+    Alert.alert('Success', 'Deck added to your library!');
+  }
+
+  if (isLoading) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundColor: '#fffafc',
+        }}
+      >
+        <ActivityIndicator size="large" color="#b45309" />
+        <Text style={{ marginTop: 16, fontSize: 16, color: '#6b7280' }}>Loading cards...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: '#fffafc' }}>
+      {/* Header */}
+      <View
+        style={{
+          backgroundColor: '#b45309',
+          paddingTop: 60,
+          paddingBottom: 20,
+          paddingHorizontal: 20,
+          borderBottomLeftRadius: 20,
+          borderBottomRightRadius: 20,
+        }}
+      >
+        <Pressable onPress={() => router.push('/')} style={{ marginBottom: 10 }}>
+          <Text style={{ color: 'white', fontSize: 16 }}>← Back</Text>
+        </Pressable>
+
+        {/* Header with Title and number of cards*/}
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            marginBottom: 12,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 28,
+              fontWeight: 'bold',
+              color: 'white',
+              flex: 1,
+            }}
+          >
+            {`${category} Cards`}
+          </Text>
+        </View>
+
+        <Text
+          style={{
+            fontSize: 16,
+            color: '#fbbf24',
+          }}
+        >
+          {amount} {amount === '1' ? 'card' : 'cards'}
+        </Text>
+      </View>
+
+      {/* Button to add to Library */}
+      <View style={{ padding: 20 }}>
+        <Pressable
+          onPress={handleSaveDeck}
+          style={{
+            backgroundColor: '#ffdd54',
+            borderRadius: 12,
+            padding: 16,
+            alignItems: 'center',
+            shadowColor: '#000',
+            shadowOpacity: 0.1,
+            shadowRadius: 5,
+            shadowOffset: { width: 0, height: 2 },
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 18,
+              fontWeight: 'bold',
+              color: '#5e2606',
+            }}
+          >
+            + Add to Your Decks
+          </Text>
+        </Pressable>
+        <Text style={styles.explanation}>* you will be able to edit the deck from Home</Text>
+      </View>
+
+      {error && (
+        <View
+          style={{
+            backgroundColor: '#fee2e2',
+            borderColor: '#fca5a5',
+            borderWidth: 1,
+            borderRadius: 8,
+            padding: 12,
+            marginHorizontal: 20,
+            marginBottom: 10,
+          }}
+        >
+          <Text style={{ color: '#dc2626', fontSize: 14 }}>{error}</Text>
+        </View>
+      )}
+
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 20 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {mockData.length === 0 ? (
+          <View
+            style={{
+              backgroundColor: '#fef3c7',
+              borderRadius: 16,
+              padding: 40,
+              alignItems: 'center',
+              marginTop: 20,
+              shadowColor: '#000',
+              shadowOpacity: 0.05,
+              shadowRadius: 10,
+              shadowOffset: { width: 0, height: 2 },
+            }}
+          >
+            <Text style={{ fontSize: 18, fontWeight: '600', color: '#b45309', marginBottom: 8 }}>
+              Error displaying cards
+            </Text>
+            <Text style={{ fontSize: 14, color: '#78350f', textAlign: 'center', marginBottom: 20 }}>
+              Please explore one more time {category}
+            </Text>
+            <Pressable
+              onPress={() => router.back()}
+              style={{
+                backgroundColor: '#b45309',
+                paddingHorizontal: 24,
+                paddingVertical: 12,
+                borderRadius: 12,
+              }}
+            >
+              <Text style={{ color: 'white', fontWeight: '600', fontSize: 16 }}>Explore Again</Text>
+            </Pressable>
+          </View>
+        ) : (
+          mockData.map((card, index) => (
+            <View
+              key={card.id}
+              style={{
+                backgroundColor: '#fef3c7',
+                borderRadius: 16,
+                padding: 20,
+                marginBottom: 16,
+                shadowColor: '#000',
+                shadowOpacity: 0.08,
+                shadowRadius: 6,
+                shadowOffset: { width: 0, height: 2 },
+              }}
+            >
+              <View
+                style={{
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: 12,
+                }}
+              >
+                <Text
+                  style={{
+                    fontSize: 14,
+                    fontWeight: '600',
+                    color: '#b45309',
+                    backgroundColor: '#ffedd5',
+                    paddingHorizontal: 12,
+                    paddingVertical: 4,
+                    borderRadius: 8,
+                  }}
+                >
+                  {card.topic}
+                </Text>
+                <Text style={{ fontSize: 12, color: '#78350f' }}>Card #{index + 1}</Text>
+              </View>
+
+              <Text
+                style={{
+                  fontSize: 16,
+                  fontWeight: '600',
+                  color: '#b45309',
+                  marginBottom: 8,
+                }}
+              >
+                Q: {card.question}
+              </Text>
+
+              <Text
+                style={{
+                  fontSize: 14,
+                  color: '#78350f',
+                  lineHeight: 20,
+                  marginBottom: 16,
+                }}
+              >
+                A: {card.answer}
+              </Text>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  explanation: {
+    color: '#f06c6c',
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 10,
+  },
+});

--- a/frontend/app/(tabs)/(explore)/subjectCards.tsx
+++ b/frontend/app/(tabs)/(explore)/subjectCards.tsx
@@ -10,14 +10,13 @@ import {
 } from 'react-native';
 
 import { useRouter, useLocalSearchParams } from 'expo-router';
-import mockData from '@/data/flashcards.json';
+import { useExploreDeckStore } from '@/store/explore-deck-store';
 
 export default function SubjectCardsScreen() {
   const router = useRouter();
   const { category, amount } = useLocalSearchParams();
+  const { flashcards, isLoading, error } = useExploreDeckStore();
 
-  const isLoading = false;
-  const error = false;
 
   function handleSaveDeck() {
     console.log('runs function from zustand to save to supabase');
@@ -53,7 +52,7 @@ export default function SubjectCardsScreen() {
           borderBottomRightRadius: 20,
         }}
       >
-        <Pressable onPress={() => router.push('/')} style={{ marginBottom: 10 }}>
+        <Pressable onPress={() => router.back()} style={{ marginBottom: 10 }}>
           <Text style={{ color: 'white', fontSize: 16 }}>← Back</Text>
         </Pressable>
 
@@ -137,7 +136,7 @@ export default function SubjectCardsScreen() {
         contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 20 }}
         showsVerticalScrollIndicator={false}
       >
-        {mockData.length === 0 ? (
+        {flashcards.length === 0 ? (
           <View
             style={{
               backgroundColor: '#fef3c7',
@@ -170,9 +169,9 @@ export default function SubjectCardsScreen() {
             </Pressable>
           </View>
         ) : (
-          mockData.map((card, index) => (
+          flashcards.map((card, index) => (
             <View
-              key={card.id}
+              key={card.question}
               style={{
                 backgroundColor: '#fef3c7',
                 borderRadius: 16,

--- a/frontend/app/(tabs)/(explore)/subjectCards.tsx
+++ b/frontend/app/(tabs)/(explore)/subjectCards.tsx
@@ -19,19 +19,18 @@ export default function SubjectCardsScreen() {
 
   async function handleSaveDeck() {
     try {
-
-    const newDeck = {
-      title: String(category),
-      subject: String(category),
-      description: `Set of explored cards in ${String(category)} category.`,
-    };
-    await addExploreFlashcardSet(newDeck);
-    Alert.alert('Success', 'Deck added to your library!', [
-      { text: 'OK', onPress: () => router.back() },
-    ]);
-  } catch (err: any) {
-    Alert.alert('Error', err.message || 'Failed to save deck. Please try again.');
-  }
+      const newDeck = {
+        title: String(category),
+        subject: String(category),
+        description: `Set of explored cards in ${String(category)} category.`,
+      };
+      await addExploreFlashcardSet(newDeck);
+      Alert.alert('Success', 'Deck added to your library!', [
+        { text: 'OK', onPress: () => router.back() },
+      ]);
+    } catch (err: any) {
+      Alert.alert('Error', err.message || 'Failed to save deck. Please try again.');
+    }
   }
 
   if (isLoading) {

--- a/frontend/app/(tabs)/(explore)/subjectCards.tsx
+++ b/frontend/app/(tabs)/(explore)/subjectCards.tsx
@@ -15,12 +15,23 @@ import { useExploreDeckStore } from '@/store/explore-deck-store';
 export default function SubjectCardsScreen() {
   const router = useRouter();
   const { category, amount } = useLocalSearchParams();
-  const { flashcards, isLoading, error } = useExploreDeckStore();
+  const { flashcards, isLoading, error, addExploreFlashcardSet } = useExploreDeckStore();
 
+  async function handleSaveDeck() {
+    try {
 
-  function handleSaveDeck() {
-    console.log('runs function from zustand to save to supabase');
-    Alert.alert('Success', 'Deck added to your library!');
+    const newDeck = {
+      title: String(category),
+      subject: String(category),
+      description: `Set of explored cards in ${String(category)} category.`,
+    };
+    await addExploreFlashcardSet(newDeck);
+    Alert.alert('Success', 'Deck added to your library!', [
+      { text: 'OK', onPress: () => router.back() },
+    ]);
+  } catch (err: any) {
+    Alert.alert('Error', err.message || 'Failed to save deck. Please try again.');
+  }
   }
 
   if (isLoading) {

--- a/frontend/app/(tabs)/(home)/addCard.tsx
+++ b/frontend/app/(tabs)/(home)/addCard.tsx
@@ -205,7 +205,7 @@ export default function CreateCardScreen() {
                 }}
               >
                 <Text style={{ textAlign: 'center', color: '#4b5563', fontWeight: '500' }}>
-                  Back to Deck
+                  Cancel
                 </Text>
               </Pressable>
             </View>

--- a/frontend/app/(tabs)/(home)/subjectCards.tsx
+++ b/frontend/app/(tabs)/(home)/subjectCards.tsx
@@ -3,8 +3,8 @@ import { View, Text, ScrollView, Pressable, ActivityIndicator, Alert } from 'rea
 
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useRouter, useLocalSearchParams, useFocusEffect } from 'expo-router';
-import { useFlashcardStore, useFlashcardSetStore } from '../../../store/deck-card-store';
-import { Flashcard } from '../../../types/Flashcard';
+import { useFlashcardStore, useFlashcardSetStore } from '@/store/deck-card-store';
+import { Flashcard } from '@/types/Flashcard';
 
 export default function SubjectCardsScreen() {
   const router = useRouter();

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -26,7 +26,7 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="(explore)/explore"
+        name="(explore)"
         options={{
           title: 'Explore',
           tabBarIcon: ({ color }) => (

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -6,6 +6,7 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 import { AuthProvider } from '../context/AuthContext';
 import Toast from 'react-native-toast-message';
+import { Provider as PaperProvider } from "react-native-paper";
 
 export default function RootLayout() {
   const [loaded] = useFonts({
@@ -17,15 +18,17 @@ export default function RootLayout() {
   }
 
   return (
-    <GluestackUIProvider>
-      <AuthProvider>
-        <Stack screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="index" />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="auto" />
-        <Toast />
-      </AuthProvider>
-    </GluestackUIProvider>
+    <PaperProvider>
+      <GluestackUIProvider>
+        <AuthProvider>
+          <Stack screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="index" />
+            <Stack.Screen name="+not-found" />
+          </Stack>
+          <StatusBar style="auto" />
+          <Toast />
+        </AuthProvider>
+      </GluestackUIProvider>
+    </PaperProvider>
   );
 }

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -6,7 +6,7 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 import { AuthProvider } from '../context/AuthContext';
 import Toast from 'react-native-toast-message';
-import { Provider as PaperProvider } from "react-native-paper";
+import { Provider as PaperProvider } from 'react-native-paper';
 
 export default function RootLayout() {
   const [loaded] = useFonts({

--- a/frontend/components/FlashcardSetCard.tsx
+++ b/frontend/components/FlashcardSetCard.tsx
@@ -29,8 +29,9 @@ export default function FlashcardSetCard({ item }: { item: FlashcardSet }) {
           onPress: async () => {
             try {
               await deleteFlashcardSet(item.id);
-              await fetchFlashcardSets();
               Alert.alert('Success', 'Deck deleted successfully!');
+              await fetchFlashcardSets();
+
             } catch (error: any) {
               Alert.alert(
                 'Cannot Delete Deck',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "expo-system-ui": "~5.0.7",
         "expo-web-browser": "~14.1.6",
         "formik": "^2.4.6",
+        "he": "^1.2.0",
         "nativewind": "^4.1.23",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -61,6 +62,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@testing-library/react-native": "^13.2.0",
+        "@types/he": "^1.2.3",
         "@types/jest": "^29.5.14",
         "@types/react": "~19.0.10",
         "babel-jest": "^30.0.0-beta.3",
@@ -6741,6 +6743,13 @@
       "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
       "license": "MIT"
     },
+    "node_modules/@types/he": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
+      "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
@@ -12076,6 +12085,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hermes-estree": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,7 @@
         "react-native": "0.79.2",
         "react-native-css-interop": "^0.1.22",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-paper": "^5.14.5",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
@@ -1646,6 +1647,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@callstack/react-theme-provider": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.9.tgz",
+      "integrity": "sha512-tTQ0uDSCL0ypeMa8T/E9wAZRGKWj8kXP7+6RYgPTfOPs9N07C9xM8P02GJ3feETap4Ux5S69D9nteq9mEj86NA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider/node_modules/deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
@@ -1988,9 +2011,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2242,9 +2265,9 @@
       }
     },
     "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2414,9 +2437,9 @@
       }
     },
     "node_modules/@expo/metro-config/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -7057,9 +7080,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7998,9 +8021,9 @@
       }
     },
     "node_modules/babel-plugin-module-resolver/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8295,9 +8318,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11882,9 +11905,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -19273,6 +19296,51 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-paper": {
+      "version": "5.14.5",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-5.14.5.tgz",
+      "integrity": "sha512-eaIH5bUQjJ/mYm4AkI6caaiyc7BcHDwX6CqNDi6RIxfxfWxROsHpll1oBuwn/cFvknvA8uEAkqLk/vzVihI3AQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "docs"
+      ],
+      "dependencies": {
+        "@callstack/react-theme-provider": "^3.0.9",
+        "color": "^3.1.2",
+        "use-latest-callback": "^0.2.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": "*"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
     },
     "node_modules/react-native-reanimated": {
       "version": "3.17.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "expo-system-ui": "~5.0.7",
     "expo-web-browser": "~14.1.6",
     "formik": "^2.4.6",
+    "he": "^1.2.0",
     "nativewind": "^4.1.23",
     "react": "19.0.0",
     "react-dom": "19.0.0",
@@ -76,6 +77,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@testing-library/react-native": "^13.2.0",
+    "@types/he": "^1.2.3",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.0.10",
     "babel-jest": "^30.0.0-beta.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
     "react-native": "0.79.2",
     "react-native-css-interop": "^0.1.22",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-paper": "^5.14.5",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",

--- a/frontend/store/deck-card-store.ts
+++ b/frontend/store/deck-card-store.ts
@@ -187,6 +187,7 @@ export const useFlashcardSetStore = create<FlashcardSetState>((set, get) => ({
     try {
       set({ isLoading: true, error: null });
       const data = await api.createFlashcardDeck(newSet.title, newSet.subject, newSet.description);
+      console.log('here is data from supabase', data);
       const transformedData = transformFlashcardSet(data);
       set((state) => ({
         flashcardSets: [transformedData, ...state.flashcardSets],

--- a/frontend/store/explore-deck-store.ts
+++ b/frontend/store/explore-deck-store.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+import { Flashcard } from '@/types/Flashcard';
+import { decode } from 'he';
+// import * as api from '../service/api';
+
+type ExploreState = {
+  isLoading: boolean;
+  error: string | null;
+  flashcards: Partial<Flashcard>[];
+  fetchExploreDeck: (amount: string, category: string, difficulty: string) => Promise<void>;
+};
+
+const categoryMap: Record<string, number> = {
+  'General Knowledge': 9,
+  'Entertainment: Books': 10,
+  'Entertainment: Film': 11,
+  'Entertainment: Music': 12,
+  'Entertainment: Musicals & Theatres': 13,
+  'Entertainment: Television': 14,
+  'Entertainment: Video Games': 15,
+  'Entertainment: Board Games': 16,
+  'Science & Nature': 17,
+  'Science: Computers': 18,
+  'Science: Mathematics': 19,
+  Mythology: 20,
+  Sports: 21,
+  Geography: 22,
+  History: 23,
+  Politics: 24,
+  Art: 25,
+  Celebrities: 26,
+  Animals: 27,
+  Vehicles: 28,
+  'Entertainment: Comics': 29,
+  'Science: Gadgets': 30,
+  'Entertainment: Japanese Anime & Manga': 31,
+  'Entertainment: Cartoon & Animations': 32,
+};
+
+export const useExploreDeckStore = create<ExploreState>((set) => ({
+  flashcards: [],
+  isLoading: false,
+  error: null,
+  fetchExploreDeck: async (amount, category, difficulty) => {
+    try {
+      set({ isLoading: true, error: null });
+
+      let url = `https://opentdb.com/api.php?amount=${amount}`;
+
+      if (category !== 'Any Category' && categoryMap[category]) {
+        url += `&category=${categoryMap[category]}`;
+      }
+
+      if (difficulty !== 'Any Difficulty') {
+        url += `&difficulty=${difficulty.toLowerCase()}`;
+      }
+
+      const response = await fetch(url);
+      const data = await response.json();
+
+      if (!data.results) throw new Error('Invalid response from API');
+
+      set({
+        flashcards: data.results.map((item: any) => ({
+          subject: decode(item.category),
+          topic: decode(item.category).replace(/^Entertainment: /, ''),
+          question: decode(item.question),
+          answer: decode(item.correct_answer),
+        })),
+        isLoading: false,
+      });
+    } catch (err: any) {
+      set({ error: err.message || 'Failed to fetch explore deck', isLoading: false });
+    }
+  },
+}));

--- a/frontend/store/explore-deck-store.ts
+++ b/frontend/store/explore-deck-store.ts
@@ -7,7 +7,7 @@ import { FlashcardSet } from '@/types/FlashcardSet';
 type ExploreState = {
   isLoading: boolean;
   error: string | null;
-  flashcards: Partial<Flashcard>[];
+  flashcards: Omit<Flashcard, 'id'>[];
   fetchExploreDeck: (amount: string, category: string, difficulty: string) => Promise<void>;
   addExploreFlashcardSet: (set: Omit<FlashcardSet, 'id' | 'flashcards'>) => Promise<void>;
 };
@@ -39,7 +39,7 @@ const categoryMap: Record<string, number> = {
   'Entertainment: Cartoon & Animations': 32,
 };
 
-export const useExploreDeckStore = create<ExploreState>((set) => ({
+export const useExploreDeckStore = create<ExploreState>((set, get) => ({
   flashcards: [],
   isLoading: false,
   error: null,
@@ -81,9 +81,10 @@ export const useExploreDeckStore = create<ExploreState>((set) => ({
       set({ error: null });
       const data = await api.createFlashcardDeck(newSet.title, newSet.subject, newSet.description);
       const deckId = data.id;
-      //   flashcards.map((item: Flashcard) => {
-      //     const data = await api.createFlashcard(item, deckId);
-      //   })
+      const { flashcards } = get();
+      for (const card of flashcards) {
+        await api.createFlashcard(card, deckId);
+      }
     } catch (error: any) {
       set({
         error: error.message || 'Failed to add explore flashcard set',

--- a/frontend/store/explore-deck-store.ts
+++ b/frontend/store/explore-deck-store.ts
@@ -78,13 +78,12 @@ export const useExploreDeckStore = create<ExploreState>((set) => ({
   },
   addExploreFlashcardSet: async (newSet) => {
     try {
-        set({ error: null });
+      set({ error: null });
       const data = await api.createFlashcardDeck(newSet.title, newSet.subject, newSet.description);
       const deckId = data.id;
-    //   flashcards.map((item: Flashcard) => {
-    //     const data = await api.createFlashcard(item, deckId);
-    //   })
-      set({ flashcards: [] });
+      //   flashcards.map((item: Flashcard) => {
+      //     const data = await api.createFlashcard(item, deckId);
+      //   })
     } catch (error: any) {
       set({
         error: error.message || 'Failed to add explore flashcard set',


### PR DESCRIPTION
## What's Added
- #### External Deck Explorer: New explore section with form to fetch trivia decks from external API
- #### SubjectCards Component: Clean display of external flashcard decks with proper UI
- #### Save to Library: One-click functionality to save external decks to personal Supabase collection
- #### Backend Service Layer: Created [flashcardDecksService.ts](vscode-file://vscode-
## Key Features
- #### Trivia API Integration: Fetch decks by category, difficulty, and amount
- #### Seamless Import: External decks save directly to user's personal library
- #### Data Ordering: Decks now fetch in creation order (newest first) for better UX
- #### Proper Error Handling: Backend validation and user-friendly error messages