### PR TITLE
Feature/change save deck route

### DIFF
--- a/backend/src/controllers/flashcards/flashcardDecksController.ts
+++ b/backend/src/controllers/flashcards/flashcardDecksController.ts
@@ -175,12 +175,13 @@ export const deleteDeck = async (
       res.status(400).json({ error: 'Invalid deck ID' });
       return;
     }
-    
+
     const forceDelete = req.query.force === 'true';
     const result = await deleteFlashcardDeck(userId, idNumber, forceDelete);
 
     if (!result.success && result.needsConfirmation) {
       res.status(200).json({ needsConfirmation: result.needsConfirmation, error: result.error });
+      return;
     }
 
     if (!result.success) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,26 +13,7 @@ const app = express();
 app.use(express.json());
 const PORT = Number(process.env.PORT) || 3000;
 
-// Logging middleware to show all API calls
-app.use((req, res, next) => {
-  const start = Date.now();
-  
-  console.log(`\n🔍 [${new Date().toISOString()}] ${req.method} ${req.url}`);
-  console.log(`📝 Headers:`, req.headers);
-  console.log(`📦 Body:`, req.body);
-  console.log(`🔗 Query:`, req.query);
-  console.log(`🆔 Params:`, req.params);
-  
-  // Log response
-  res.on('finish', () => {
-    const duration = Date.now() - start;
-    console.log(`✅ [${new Date().toISOString()}] ${req.method} ${req.url} - ${res.statusCode} (${duration}ms)`);
-    console.log(`📤 Response:`, res.locals.responseData || 'No response data logged');
-    console.log('─'.repeat(80));
-  });
-  
-  next();
-});
+// Logging middleware disabled for cleaner terminal output
 
 // Swagger setup
 const swaggerOptions = {

--- a/frontend/app/(tabs)/(home)/addDeck.tsx
+++ b/frontend/app/(tabs)/(home)/addDeck.tsx
@@ -66,14 +66,7 @@ export default function AddDeckScreen() {
         ]);
       } else {
         const deckData = { ...values, flashcards: [] };
-        await addFlashcardSet(deckData);
-        await fetchFlashcardSets();
-
-        // Find the newly created deck
-        const { flashcardSets } = useFlashcardSetStore.getState();
-        const newDeck = flashcardSets.find(
-          (deck) => deck.subject === values.subject && deck.title === values.title
-        );
+        const newDeck = await addFlashcardSet(deckData);
 
         resetForm();
 
@@ -83,7 +76,7 @@ export default function AddDeckScreen() {
             onPress: () =>
               router.navigate({
                 pathname: './subjectCards',
-                params: { subject: values.subject, deckId: newDeck?.id || '' },
+                params: { subject: values.subject, deckId: newDeck.id },
               }),
           },
         ]);

--- a/frontend/app/(tabs)/(home)/addDeck.tsx
+++ b/frontend/app/(tabs)/(home)/addDeck.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
@@ -19,7 +19,6 @@ export default function AddDeckScreen() {
   const router = useRouter();
   const { deckId } = useLocalSearchParams();
   const [isLoading, setIsLoading] = useState(false);
-  const [formKey, setFormKey] = useState(0);
 
   const { getFlashcardSetById, addFlashcardSet, updateFlashcardSet, fetchFlashcardSets, error } =
     useFlashcardSetStore();
@@ -28,11 +27,6 @@ export default function AddDeckScreen() {
   const deckIdNumber = deckIdString ? parseInt(deckIdString, 10) : undefined;
   const existingDeck = deckIdNumber ? getFlashcardSetById(deckIdNumber) : null;
   const isEditMode = !!existingDeck;
-
-  // Reset form when switching between create/edit modes
-  useEffect(() => {
-    setFormKey(prev => prev + 1);
-  }, [isEditMode]);
 
   const validationSchema = Yup.object().shape({
     title: Yup.string()
@@ -165,7 +159,6 @@ export default function AddDeckScreen() {
         )}
 
         <Formik
-          key={formKey}
           initialValues={initialValues}
           validationSchema={validationSchema}
           onSubmit={handleSubmit}

--- a/frontend/app/(tabs)/(home)/index.tsx
+++ b/frontend/app/(tabs)/(home)/index.tsx
@@ -68,7 +68,7 @@ export default function HomeScreen() {
         <Heading style={styles.heading}>Your Flashcard Decks</Heading>
 
         <HStack style={styles.addDeckWrapper}>
-          <Button style={styles.addDeckButton} onPress={() => router.navigate('./addDeck')}>
+          <Button style={styles.addDeckButton} onPress={() => router.push('./addDeck')}>
             <ButtonText style={styles.addDeckText}>+ New Deck</ButtonText>
           </Button>
         </HStack>

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -24,7 +24,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const restoreSession = async () => {
       try {
         const storedSession = await AsyncStorage.getItem(STORAGE_KEY);
-        console.log('Stored session:', storedSession);
+
         if (storedSession) {
           const parsedSession = JSON.parse(storedSession);
           setSession(parsedSession);
@@ -44,7 +44,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const saveSession = async (session: any) => {
     if (session) {
       await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(session));
-      console.log('Session saved:', session);
+
     } else {
       await AsyncStorage.removeItem(STORAGE_KEY);
       console.log('Session removed');
@@ -63,7 +63,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setIsAuthenticated(true);
       setSession(sessionWithTimestamp);
       await saveSession(sessionWithTimestamp);
-      console.log('Login result session:', sessionWithTimestamp); // debug
+
     } catch (error: any) {
       setIsAuthenticated(false);
       setSession(null);

--- a/frontend/store/deck-card-store.ts
+++ b/frontend/store/deck-card-store.ts
@@ -140,7 +140,7 @@ interface FlashcardSetState {
   isLoading: boolean;
   isDeleting: boolean;
   error: string | null;
-  addFlashcardSet: (set: Omit<FlashcardSet, 'id' | 'createdAt' | 'updatedAt'>) => Promise<void>;
+  addFlashcardSet: (set: Omit<FlashcardSet, 'id' | 'createdAt' | 'updatedAt'>) => Promise<FlashcardSet>;
   updateFlashcardSet: (id: number, updatedSet: Partial<FlashcardSet>) => Promise<void>;
   deleteFlashcardSet: (
     id: number,
@@ -199,6 +199,7 @@ export const useFlashcardSetStore = create<FlashcardSetState>((set, get) => ({
         flashcardSets: [transformedData, ...state.flashcardSets],
         isLoading: false,
       }));
+      return transformedData; // Return the new deck!
     } catch (error: any) {
       set({
         error: error.message || 'Failed to add flashcard set',


### PR DESCRIPTION
### Navigation Update
Restored navigation flow to redirect users back to the subject screen upon successful deck creation.

### Backend Error Resolution
Fixed the "Cannot set headers after they are sent" error in the deleteDeck controller by ensuring responses are not duplicated.

### Form Behavior Fixes
Added resetForm() call after successful deck creation in order to clear the form immediately after creating a new deck

### Testing

- Manually tested deck creation, editing, and deletion workflows.
- Verified backend controller responses and ensured no duplicate headers.
- Confirmed navigation and form behavior are functioning as expected.

### Notes

- No breaking changes introduced.
- These fixes improve form reliability, backend stability, and overall app usability.